### PR TITLE
Writing a log of SC events to eventlog.txt

### DIFF
--- a/neo-gui/Program.cs
+++ b/neo-gui/Program.cs
@@ -76,6 +76,13 @@ namespace Neo
         [STAThread]
         public static void Main()
         {
+            // Create eventlog.txt for writing event logs to
+            using (StreamWriter sw = File.CreateText("eventlog.txt")) 
+            {
+                sw.WriteLine("Event log started at {0}", DateTime.Now.ToString());
+                sw.WriteLine();
+            }
+
             AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);

--- a/neo-gui/UI/MainForm.cs
+++ b/neo-gui/UI/MainForm.cs
@@ -1043,6 +1043,16 @@ namespace Neo.UI
                     }
                 }, -1);
 
+            // Append the entry to the event log
+            using (StreamWriter sw = File.AppendText("eventlog.txt")) 
+            {
+                sw.WriteLine(localDateTime.ToString());
+                sw.WriteLine(contract.Name.ToString());
+                sw.WriteLine(eventType);
+                sw.WriteLine(eventMessage);
+                sw.WriteLine();
+            }
+
             if (listView4.InvokeRequired)
             {
                 // call is coming from a non ui thread


### PR DESCRIPTION
Cleared at startup.

Example:
```
Event log started at 02/10/2017 21:25:12

02/10/2017 21:26:39
CLKTTest
Notify
CLWalletValidateFail
```

There might be a better way to do it - just wanted to get the ball rolling.