### PR TITLE
Increase txtScriptHash.MaxLength to 42 to accommodate 0x prefix

### DIFF
--- a/neo-gui/UI/InvokeContractDialog.resx
+++ b/neo-gui/UI/InvokeContractDialog.resx
@@ -286,7 +286,7 @@
     <value>5, 4, 5, 4</value>
   </data>
   <data name="txtScriptHash.MaxLength" type="System.Int32, mscorlib">
-    <value>40</value>
+    <value>42</value>
   </data>
   <data name="txtScriptHash.Size" type="System.Drawing.Size, System.Drawing">
     <value>574, 31</value>


### PR DESCRIPTION
Copy/pasting a scripthash from the latest version of the View Contract dialog into the Invoke Contract dialog causes the last byte to be truncated, because the 42-byte-long scripthash value with the added 0x prefix does not fit into the maximum length of txtScriptHash which is expecting only 40 bytes. 

This has led to some confusion for users, because simply removing the 0x from the beginning of the pasted scripthash leaves a truncated scripthash value which is still incorrect. This fix increases the maximum length of the field to 42 bytes to alleviate this.